### PR TITLE
Adding :REVERSE_ID syntax to links

### DIFF
--- a/plyxproto/model.py
+++ b/plyxproto/model.py
@@ -105,7 +105,8 @@ class LinkDefinition(SourceElement):
             dst_port,
             linespan=None,
             lexspan=None,
-            p=None):
+            p=None,
+            reverse_id=None):
         super(
             LinkDefinition,
             self).__init__(
@@ -128,6 +129,9 @@ class LinkDefinition(SourceElement):
 
         self.dst_port = dst_port
         Base.p(self.dst_port, self)
+
+        self.reverse_id = reverse_id
+        Base.p(self.reverse_id, self)
 
     def accept(self, visitor):
         visitor.visit_LinkDefinition(self)

--- a/plyxproto/parser.py
+++ b/plyxproto/parser.py
@@ -218,6 +218,10 @@ class ProtobufParser(object):
         '''field_id : NUM'''
         p[0] = LU.i(p, 1)
 
+    def p_reverse_id(self, p):
+        '''reverse_id : NUM'''
+        p[0] = LU.i(p, 1)
+
     def p_rvalue(self, p):
         '''rvalue : NUM
                   | TRUE
@@ -367,6 +371,32 @@ class ProtobufParser(object):
 
         self.lh.set_parse_object(p[0], p)
 
+    # TODO: Add directives to link definition
+    def p_link_definition_with_reverse (self, p):
+        '''link_definition_with_reverse : field_modifier link_type field_name policy_opt ARROW dotname slash_name colon_fieldname EQ field_id COLON reverse_id field_directives SEMI'''
+        p[0] = LinkSpec(
+            FieldDefinition(
+                LU.i(
+                    p, 1), Name('int32'), LU.i(
+                    p, 3), LU.i(
+                    p, 4), LU.i(
+                        p, 10), [
+                            FieldDirective(
+                                Name('type'), Name('link')), FieldDirective(
+                                    Name('model'), LU.i(
+                                        p, 6))] + srcPort(
+                                            LU.i(
+                                                p, 8)) + LU.i(
+                                                    p, 13)), LinkDefinition(
+                                                        LU.i(
+                                                            p, 2), LU.i(
+                                                                p, 3), LU.i(
+                                                                    p, 6), LU.i(
+                                                                        p, 7), LU.i(
+                                                                            p, 8), reverse_id= LU.i(p, 12)))
+
+        self.lh.set_parse_object(p[0], p)
+
     # Root of the field declaration.
     def p_field_definition(self, p):
         '''field_definition : field_modifier field_type field_name policy_opt EQ field_id field_directives SEMI'''
@@ -474,6 +504,7 @@ class ProtobufParser(object):
     def p_message_body_part(self, p):
         '''message_body_part : field_definition
                            | link_definition
+                           | link_definition_with_reverse
                            | enum_definition
                            | option_directive
                            | message_definition

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup
 
 setup(
     name='plyxproto',
-    version='3.1.0.dev0',
+    version='3.1.0',
     description='xproto parser and processor',
     author='Dusan Klinec (original protobuf parser), Sapan Bhatia (xproto extensions), Zack Williams (maintenance), Scott Baker (maintenance)',
     author_email='sapan@opennetworking.org',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup
 
 setup(
     name='plyxproto',
-    version='3.1.0',
+    version='3.1.0.dev0',
     description='xproto parser and processor',
     author='Dusan Klinec (original protobuf parser), Sapan Bhatia (xproto extensions), Zack Williams (maintenance), Scott Baker (maintenance)',
     author_email='sapan@opennetworking.org',

--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,9 @@ from setuptools import setup
 
 setup(
     name='plyxproto',
-    version='3.0.0',
+    version='3.1.0',
     description='xproto parser and processor',
-    author='Dusan Klinec (original protobuf parser), Sapan Bhatia (xproto extensions), Zack Williams (maintenance)',
+    author='Dusan Klinec (original protobuf parser), Sapan Bhatia (xproto extensions), Zack Williams (maintenance), Scott Baker (maintenance)',
     author_email='sapan@opennetworking.org',
     url='https://github.com/sb98052/plyprotobuf',
     license='Apache Software License',


### PR DESCRIPTION
This is an optional syntax that allows a reverse link to be specified. For example,

required manytoone owner->Service:owned_trust_domains = 2:1011 [null = False, db_index = True, blank = False, help_text = "Service partioned by this trust domain"];

The above says to insert owner at field number 2, and the reverse link at offset 1011.

